### PR TITLE
Adapts leading-colon-colon example to use top-level use braces.

### DIFF
--- a/src/file_read.rs
+++ b/src/file_read.rs
@@ -1,4 +1,4 @@
-use extern::std::{fs::File, io::{self, BufRead, BufReader}, path::Path};
+use ::std::{fs::File, io::{self, BufRead, BufReader}, path::Path};
 
 crate fn for_each_line(
     path: impl AsRef<Path>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,11 +4,10 @@
 
 mod file_read;
 
-use crate::file_read::for_each_line;
-
-use extern::{
-    regex::Regex,
-    std::{
+use {
+    ::crate::file_read::for_each_line,
+    ::regex::Regex,
+    ::std::{
         env,
         process,
         io::{self, Write}


### PR DESCRIPTION
As suggested in the forums; this adapts the leading-colon-colon example to use top-level braces, shortening the number of `use` statements one has to write (a sensible progression of grouping module imports with braces.)